### PR TITLE
Support event subscription for geth-rpcnode

### DIFF
--- a/endpoint/EventsForGoEth.go
+++ b/endpoint/EventsForGoEth.go
@@ -1,0 +1,82 @@
+package endpoint
+
+import (
+	"aurora-relayer-go-common/endpoint"
+	eventbroker "aurora-relayer-go-common/rpcnode/github-ethereum-go-ethereum/events"
+	"aurora-relayer-go-common/utils"
+	"context"
+
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type EventsForGoEth struct {
+	*endpoint.Endpoint
+	eventBroker *eventbroker.EventBroker
+	newHeadsCh  chan *utils.BlockResponse
+	logsCh      chan []*utils.LogResponse
+}
+
+func NewEventsForGoEth(ep *endpoint.Endpoint, eb *eventbroker.EventBroker) *EventsForGoEth {
+	return &EventsForGoEth{
+		Endpoint:    ep,
+		eventBroker: eb,
+		newHeadsCh:  make(chan *utils.BlockResponse, eventbroker.NewHeadsChSize),
+		logsCh:      make(chan []*utils.LogResponse, eventbroker.LogsChSize),
+	}
+}
+
+// NewHeads send a notification each time a new block is appended to the chain, including chain reorganizations.
+func (e *EventsForGoEth) NewHeads(ctx context.Context) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+	rpcSub := notifier.CreateSubscription()
+
+	go func() {
+		newHeadsSubs := e.eventBroker.SubscribeNewHeads(e.newHeadsCh)
+		for {
+			select {
+			case h := <-e.newHeadsCh:
+				notifier.Notify(rpcSub.ID, h)
+			case <-rpcSub.Err():
+				e.eventBroker.UnsubscribeFromNewHeads(newHeadsSubs)
+				return
+			case <-notifier.Closed():
+				e.eventBroker.UnsubscribeFromNewHeads(newHeadsSubs)
+				return
+			}
+		}
+	}()
+
+	return rpcSub, nil
+}
+
+// Logs send a notification each time logs included in new imported block and match the given filter criteria.
+func (e *EventsForGoEth) Logs(ctx context.Context, subOpts utils.LogSubscriptionOptions) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+	rpcSub := notifier.CreateSubscription()
+
+	go func() {
+		logsSubs := e.eventBroker.SubscribeLogs(subOpts, e.logsCh)
+		for {
+			select {
+			case logs := <-e.logsCh:
+				for _, log := range logs {
+					notifier.Notify(rpcSub.ID, &log)
+				}
+			case <-rpcSub.Err():
+				e.eventBroker.UnsubscribeFromLogs(logsSubs)
+				return
+			case <-notifier.Closed():
+				e.eventBroker.UnsubscribeFromLogs(logsSubs)
+				return
+			}
+		}
+	}()
+
+	return rpcSub, nil
+}

--- a/main.go
+++ b/main.go
@@ -10,11 +10,12 @@ import (
 	goEthereum "aurora-relayer-go-common/rpcnode/github-ethereum-go-ethereum"
 	"aurora-relayer-go/endpoint"
 	"aurora-relayer-go/indexer"
-	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/spf13/cobra"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -78,6 +79,13 @@ func main() {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   endpoint.NewCustomEth(baseEndpoint),
+		})
+
+		eventsEndpoint := endpoint.NewEventsForGoEth(baseEndpoint, rpcNode.EventBroker)
+		rpcAPIs = append(rpcAPIs, rpc.API{
+			Namespace: "eth",
+			Version:   "1.0",
+			Service:   eventsEndpoint,
 		})
 
 		rpcNode.RegisterAPIs(rpcAPIs)


### PR DESCRIPTION
This PR implements event subscription and publish mechanism for geth-rpc node. The PR covers the following items.

- ETH event subscription endpoints are added via `go-ethereum/rpc` and `common library eventbroker` support.
- Events endpoint is created in `main.go`