### PR TITLE
18: Make async and sync sendRawTransactions configurable

### DIFF
--- a/relayer.yaml
+++ b/relayer.yaml
@@ -36,7 +36,9 @@ endpoint:
   engine:
     nearNetworkID: testnet
     nearNodeURL: https://archival-rpc.testnet.near.org
-    nearReceiverID:
+    signer:
+    signerKey:
+    asyncSendRawTxs: false
     minGasPrice: 0
     minGasLimit: 21000
     gasForNearTxsCall: 300000000000000


### PR DESCRIPTION
This PR fixes issues [18](https://github.com/aurora-is-near/aurora-relayer-go/issues/18) and [19](https://github.com/aurora-is-near/aurora-relayer-go/issues/19)

Issue 18 Make async and sync sendRawTransaction configurable

- A new configuration item, `asyncSendRawTxs`, added to the `relayer.yaml` file under `endpoint -> engine`
- Sync and aysnc version of the `eth_sendRawTransaction` functions are called based on the config item


Issue 19 Create a config directory to store Near Credentials

- Near Credential configuration parameter names updated to comply with the old relayer
Example -> `signer: xxx.testnet` , `signerKey: config/xxx.testnet.json`
`signer` is mandatory. If `signerKey`is not introduced the Near Credentials are searched in `$HOME/.near-credentials/`