### PR TITLE
37: Add support for missing endpoints

### DIFF
--- a/config/mainnet.yaml
+++ b/config/mainnet.yaml
@@ -15,7 +15,6 @@ db:
         InMemory: false
         DetectConflicts: false
 endpoint:
-  chainID: 1313161554
   filterFilePath: config/filter.yaml
   engine:
     nearNetworkID: mainnet
@@ -32,11 +31,12 @@ endpoint:
   eth:
     protocolVersion: 0x41
     hashrate: 0
-    gas: 6721975
+    gasEstimate: 0x6691b7
+    gasPrice: 0x42c1d80
   proxyEndpoints:
     url: "https://mainnet.aurora.dev:443"
     endpoints:
-    -
+    - eth_gasEstimate
   disabledEndpoints:
     -
 rpcNode:

--- a/config/testnet.yaml
+++ b/config/testnet.yaml
@@ -15,7 +15,6 @@ db:
         InMemory: false
         DetectConflicts: false
 endpoint:
-  chainID: 1313161555
   filterFilePath: config/filter.yaml
   engine:
     nearNetworkID: testnet
@@ -32,7 +31,8 @@ endpoint:
   eth:
     protocolVersion: 0x41
     hashrate: 0
-    gas: 6721975
+    gasEstimate: 0x6691b7
+    gasPrice: 0x42c1d80
   proxyEndpoints:
     url: "https://testnet.aurora.dev:443"
     endpoints:

--- a/endpoint/engineEth_test.go
+++ b/endpoint/engineEth_test.go
@@ -194,8 +194,7 @@ func TestNetEndpointsCompare(t *testing.T) {
 	if err != nil {
 		t.Error("Version request error:", err)
 	}
-	// Format the received response to compare with the base result
-	respHex := resp.Text(10)
+	respHex := *resp
 
 	var respExpected string
 	err = rpcClientBase.CallContext(ctx, &respExpected, "net_version")

--- a/endpoint/engineNet.go
+++ b/endpoint/engineNet.go
@@ -2,7 +2,7 @@ package endpoint
 
 import (
 	"aurora-relayer-go-common/endpoint"
-	"aurora-relayer-go-common/types/common"
+	errs "aurora-relayer-go-common/types/errors"
 	"context"
 )
 
@@ -16,8 +16,13 @@ func NewEngineNet(eEth *EngineEth) *EngineNet {
 }
 
 // Version returns the chain id of the current network. Therefore, directly calls the `chainId`` method under `engineEth` endpoint
-func (e *EngineNet) Version(ctx context.Context) (*common.Uint256, error) {
-	return endpoint.Process(ctx, "net_version", e.Endpoint, func(ctx context.Context) (*common.Uint256, error) {
-		return e.chainId(ctx)
+func (e *EngineNet) Version(ctx context.Context) (*string, error) {
+	return endpoint.Process(ctx, "net_version", e.Endpoint, func(ctx context.Context) (*string, error) {
+		version, err := e.chainId(ctx)
+		if err != nil {
+			return nil, &errs.GenericError{Err: err}
+		}
+		base10str := version.Text(10)
+		return &base10str, nil
 	})
 }

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 		baseEndpoint.WithProcessor(processor.NewProxy())
 
 		ethEndpoint := commonEndpoint.NewEth(baseEndpoint)
+		netEndpoint := commonEndpoint.NewNet(baseEndpoint)
 		web3Endpoint := commonEndpoint.NewWeb3(baseEndpoint)
 
 		rpcNode, err := goEthereum.New()
@@ -62,6 +63,11 @@ func main() {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   commonEndpoint.NewEthProcessorAware(ethEndpoint),
+		})
+		rpcAPIs = append(rpcAPIs, rpc.API{
+			Namespace: "net",
+			Version:   "1.0",
+			Service:   commonEndpoint.NewNetProcessorAware(netEndpoint),
 		})
 		rpcAPIs = append(rpcAPIs, rpc.API{
 			Namespace: "web3",


### PR DESCRIPTION
- Adds gasPrice and gasEstimate parameters to the config file
- Fixes `net_version` endpoint
- Support `net_` endpoints