### PR TITLE
41: Fix the hash returned from AsyncSendRawTxs

### DIFF
--- a/endpoint/engineEth.go
+++ b/endpoint/engineEth.go
@@ -206,8 +206,9 @@ func (e *EngineEth) asyncSendRawTransaction(txsBytes []byte) (*string, error) {
 	if err != nil {
 		return nil, &errs.GenericError{Err: err}
 	}
-
-	return resp, nil
+	txsHash := "0x" + hex.EncodeToString(crypto.Keccak256(txsBytes))
+	e.Logger.Info().Msgf("Near txs hash is: %s, for Eth txs hash: %s", *resp, txsHash)
+	return &txsHash, nil
 }
 
 // syncSendRawTransaction submits a raw transaction to engine synchronously

--- a/endpoint/engineEth_test.go
+++ b/endpoint/engineEth_test.go
@@ -306,7 +306,7 @@ func TestEthEndpointsStatic(t *testing.T) {
 			case *string:
 				if d.expectedResult == "anyHash" {
 					tmp := *v
-					if len(tmp) != 44 {
+					if len(tmp) != 66 {
 						t.Errorf("incorrect response: expected %s, got %s", d.expectedResult, *v)
 					}
 				} else if *v != d.expectedResult {


### PR DESCRIPTION
* Keccak256 hash of the raw txs is now returned
* The corresponding Near txs hash is logged for debug purposes
* Test file updated accordingly