### PR TITLE
(#57) add config option to allow reindexing

### DIFF
--- a/indexer/config.go
+++ b/indexer/config.go
@@ -10,6 +10,7 @@ import (
 const (
 	DefaultGenesisBlock        = 9820210
 	DefaultKeepFiles           = false
+	DefaultForceReindex        = false
 	DefaultFromBlock           = DefaultGenesisBlock
 	DefaultToBlock             = 0
 	DefaultSubFolderBatchSize  = 10000
@@ -22,6 +23,7 @@ const (
 
 type Config struct {
 	KeepFiles           bool   `mapstructure:"keepFiles"`
+	ForceReindex        bool   `mapstructure:"forceReindex"`
 	RetryCountOnFailure uint8  `mapstructure:"retryCountOnFailure"`
 	SubFolderBatchSize  uint16 `mapstructure:"subFolderBatchSize"`
 	GenesisBlock        uint64 `mapstructure:"genesisBlock"`
@@ -34,6 +36,7 @@ type Config struct {
 func defaultConfig() *Config {
 	return &Config{
 		KeepFiles:           DefaultKeepFiles,
+		ForceReindex:        DefaultForceReindex,
 		RetryCountOnFailure: DefaultRetryCountOnFailure,
 		GenesisBlock:        DefaultGenesisBlock,
 		FromBlock:           DefaultFromBlock, // inclusive


### PR DESCRIPTION
see #57 for more details.

adding a config option `indexer.forceReindex` (default `false`) to introduce re-indexing capability to users
if `indexer.forceReindex` is `true` indexer can re-index any block range defined by `indexer.fromBlock` and `indexer.toBlock` even if those blocks have already been stored in DB. 
Upon completion of re-indexing, indexer will continue indexing new blocks starting from the latest block stored in DB.