### PR TITLE
Support a separate chainId config under PrehistoryIndexer section

### DIFF
--- a/config/mainnet.yaml
+++ b/config/mainnet.yaml
@@ -80,5 +80,6 @@ prehistoryIndexer:
   from: 0
   to: 37157758               # cannot be higher than prehistoryHeight
   batchSize: 10000
+  chainId: 1313161554
   archiveURL: "postgres://public_readonly:nearprotocol@104.199.89.51/mainnet_explorer"
 

--- a/config/testnet.yaml
+++ b/config/testnet.yaml
@@ -80,4 +80,5 @@ prehistoryIndexer:
   from: 0
   to: 47354108                # cannot be higher than prehistoryHeight
   batchSize: 10000
+  chainId: 1313161555
   archiveURL: "postgres://public_readonly:nearprotocol@35.184.214.98/testnet_explorer"


### PR DESCRIPTION
This PR supports the issue https://github.com/aurora-is-near/relayer2-base/issues/90