### PR TITLE
81: Support CORS preflight headers

### DIFF
--- a/config/mainnet.yaml
+++ b/config/mainnet.yaml
@@ -46,8 +46,10 @@ rpcNode:
   geth:
     HTTPHost: localhost
     HTTPPort: 8545
-    HTTPVirtualHosts:
-      - localhost
+    HTTPCors: 
+      - "*"
+    HTTPVirtualHosts: 
+      - "*"
     HTTPModules:
       - "net"
       - "web3"

--- a/config/testnet.yaml
+++ b/config/testnet.yaml
@@ -46,8 +46,10 @@ rpcNode:
   geth:
     HTTPHost: localhost
     HTTPPort: 8545
-    HTTPVirtualHosts:
-      - localhost
+    HTTPCors: 
+      - "*"
+    HTTPVirtualHosts: 
+      - "*"
     HTTPModules:
       - "net"
       - "web3"

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.2
 
 require (
 	github.com/aurora-is-near/near-api-go v0.0.13-0.20221011140300-30882c6356c4
-	github.com/aurora-is-near/relayer2-base v1.0.0-rc.1
+	github.com/aurora-is-near/relayer2-base v1.0.0-rc.2
 	github.com/ethereum/go-ethereum v1.10.25
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/aurora-is-near/go-jsonrpc/v3 v3.1.1 h1:Nw9J9K7CksfVBa9uCVfvf1uAIQRhrN
 github.com/aurora-is-near/go-jsonrpc/v3 v3.1.1/go.mod h1:Li013EFlPu3crtlFQtWJAeE7VmdhSsxOpRoop1J0icw=
 github.com/aurora-is-near/near-api-go v0.0.13-0.20221011140300-30882c6356c4 h1:b2Af6VFU4iETG9wiBlQT9EWO93t5qZje/jQUKcpqSyo=
 github.com/aurora-is-near/near-api-go v0.0.13-0.20221011140300-30882c6356c4/go.mod h1:u1KDIqjCl+g+Ndp8izReS5zXI05YWCgQR3iOYXhnhHI=
-github.com/aurora-is-near/relayer2-base v1.0.0-rc.1 h1:CEbg+ROnRlj0ffRDpLSeGp5NFC8PGYTG/zKI++82RZQ=
-github.com/aurora-is-near/relayer2-base v1.0.0-rc.1/go.mod h1:/iT4YEDCJAq2BwAvt4uOge5FIiRU6vr9BfJxW/n8guQ=
+github.com/aurora-is-near/relayer2-base v1.0.0-rc.2 h1:/UT8nwNWQNSoBZWG5zgKss+LEfNAeJ+LlNPr1Xk8J6Q=
+github.com/aurora-is-near/relayer2-base v1.0.0-rc.2/go.mod h1:/iT4YEDCJAq2BwAvt4uOge5FIiRU6vr9BfJxW/n8guQ=
 github.com/aurora-is-near/stream-backup v0.0.0-20221212013533-1e06e263c3f7 h1:aHMsjwM2KJ6EO9H7f1UgFD95c+d9BTpA43NQgZ6hiaM=
 github.com/aurora-is-near/stream-backup v0.0.0-20221212013533-1e06e263c3f7/go.mod h1:71KeQcNFeKIHH0WeppWnXZBfwpGo/YwLK8TtC+r+TfY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
This PR
 * adds sample `HTTPCors` and `HTTPVirtualHosts` keys to configuration files
 * updates the `relayer2-base` dependency to a newer version where CORS preflight issue is solved 