### PR TITLE
bump relayer2-base and near-api-go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ go 1.18
 replace github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.2
 
 require (
-	github.com/aurora-is-near/near-api-go v0.0.13-0.20221011140300-30882c6356c4
-	github.com/aurora-is-near/relayer2-base v1.0.3
+	github.com/aurora-is-near/near-api-go v0.0.13-0.20230718083121-2b3b0cdd7ac4
+	github.com/aurora-is-near/relayer2-base v1.0.5
 	github.com/ethereum/go-ethereum v1.10.25
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -50,10 +50,10 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aurora-is-near/go-jsonrpc/v3 v3.1.1 h1:Nw9J9K7CksfVBa9uCVfvf1uAIQRhrNG677q8eH1gtVg=
 github.com/aurora-is-near/go-jsonrpc/v3 v3.1.1/go.mod h1:Li013EFlPu3crtlFQtWJAeE7VmdhSsxOpRoop1J0icw=
-github.com/aurora-is-near/near-api-go v0.0.13-0.20221011140300-30882c6356c4 h1:b2Af6VFU4iETG9wiBlQT9EWO93t5qZje/jQUKcpqSyo=
-github.com/aurora-is-near/near-api-go v0.0.13-0.20221011140300-30882c6356c4/go.mod h1:u1KDIqjCl+g+Ndp8izReS5zXI05YWCgQR3iOYXhnhHI=
-github.com/aurora-is-near/relayer2-base v1.0.3 h1:5e/lyGllvdVXe6e/y51Q2oE8MsWf63M6ALM6lwxr19o=
-github.com/aurora-is-near/relayer2-base v1.0.3/go.mod h1:HMQW4vlcW1/jjMy/w8kY+b+Z3VZOrNhEC+rotjXNtqs=
+github.com/aurora-is-near/near-api-go v0.0.13-0.20230718083121-2b3b0cdd7ac4 h1:CSR9l311tsTj8EgQ/jqzLod7u7V1tq3HDnRRKZrNNGY=
+github.com/aurora-is-near/near-api-go v0.0.13-0.20230718083121-2b3b0cdd7ac4/go.mod h1:u1KDIqjCl+g+Ndp8izReS5zXI05YWCgQR3iOYXhnhHI=
+github.com/aurora-is-near/relayer2-base v1.0.5 h1:5cWLKUXJh0KVlqv7GtLKmwZn3J0Kgwzft35PNSZAvAQ=
+github.com/aurora-is-near/relayer2-base v1.0.5/go.mod h1:HMQW4vlcW1/jjMy/w8kY+b+Z3VZOrNhEC+rotjXNtqs=
 github.com/aurora-is-near/stream-backup v0.0.0-20221212013533-1e06e263c3f7 h1:aHMsjwM2KJ6EO9H7f1UgFD95c+d9BTpA43NQgZ6hiaM=
 github.com/aurora-is-near/stream-backup v0.0.0-20221212013533-1e06e263c3f7/go.mod h1:71KeQcNFeKIHH0WeppWnXZBfwpGo/YwLK8TtC+r+TfY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/indexer/config.go
+++ b/indexer/config.go
@@ -1,7 +1,7 @@
 package indexer
 
 import (
-	"github.com/aurora-is-near/relayer2-base/cmd"
+	"github.com/aurora-is-near/relayer2-base/cmdutils"
 	"github.com/aurora-is-near/relayer2-base/log"
 
 	"github.com/spf13/viper"
@@ -51,7 +51,7 @@ func GetConfig() *Config {
 	config := defaultConfig()
 	sub := viper.Sub(configPath)
 	if sub != nil {
-		cmd.BindSubViper(sub, configPath)
+		cmdutils.BindSubViper(sub, configPath)
 		if err := sub.Unmarshal(&config); err != nil {
 			log.Log().Warn().Err(err).Msgf("failed to parse configuration [%s] from [%s], "+
 				"falling back to defaults", configPath, viper.ConfigFileUsed())


### PR DESCRIPTION
* bump relayer2-base version to v1.0.5
* bump near-api-go version to latest commit