### PR TITLE
use archival node to fetch keys on start up

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -64,7 +64,7 @@ func NewAccount(config *endpoint.EngineConfig) (*Account, error) {
 		return nil, fmt.Errorf("failed to load Near account from path: [%s]", nearCfg.KeyPath)
 	}
 
-	txnProcessor, err := NewTxnProcessor(config, nearAccount)
+	txnProcessor, err := NewTxnProcessor(config, nearAccount, nearArchivalAccount)
 	if err != nil {
 		return nil, err
 	}

--- a/account/txnProcessor.go
+++ b/account/txnProcessor.go
@@ -45,7 +45,7 @@ type nonceCache struct {
 
 // NewTxnProcessor creates and starts transaction processor which is responsible for sending received Eth transaction to
 // Near in a controlled fashion. Also see, TxnProcessor.Submit(*TxnReq)
-func NewTxnProcessor(config *endpoint.EngineConfig, account *near.Account) (*TxnProcessor, error) {
+func NewTxnProcessor(config *endpoint.EngineConfig, account *near.Account, archivalAccount *near.Account) (*TxnProcessor, error) {
 
 	var mapper TxnMapper
 	switch config.FunctionKeyMapper {
@@ -60,7 +60,7 @@ func NewTxnProcessor(config *endpoint.EngineConfig, account *near.Account) (*Txn
 		config:         config,
 		account:        account,
 		logger:         log.Log(),
-		keys:           account.GetVerifiedAccessKeys(),
+		keys:           archivalAccount.GetVerifiedAccessKeys(),
 		ethNonceCache:  make(map[string]*nonceCache),
 		nearNonceCache: make(map[string]*nonceCache),
 		ordered:        make([]*TxnQ[TxnReq], 0),


### PR DESCRIPTION
this change is required for standalone-rpc, 
relayer cannot use refiner as a near node to fetch near keys during start up because, refiner waits for relayer to start up at first place